### PR TITLE
fix: start detached & follow logs

### DIFF
--- a/validator.sh
+++ b/validator.sh
@@ -57,7 +57,7 @@ docker-compose down
 # Start up the services with docker-compose
 echo "Validator ($VALIDATOR_DIR) is now starting."
 
-docker-compose up
+docker-compose up -d && docker-compose logs -f
 
 # Check if docker-compose started correctly
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
I've recently spun up my validator, and the process was incredibly easy to do.

The only thing I'd change is: starting the docker compose detached and following logs afterwards. That way if someone with less experience exits, it doesn't force the compose to go down.