### PR TITLE
Fix jq syntax

### DIFF
--- a/validator.sh
+++ b/validator.sh
@@ -40,7 +40,7 @@ cd "$VALIDATOR_DIR"
 
 # Edit the JSON configuration file
 jq --arg pk "$PRIVATE_KEY" --arg ep "$ETH_RPC_ENDPOINT" \
-   '.node.staker.["parent-chain-wallet"]."private-key" = $pk |
+   '.node.staker["parent-chain-wallet"]."private-key" = $pk |
     .["parent-chain"].connection.url = $ep' "$CONFIG_FILE" > tmp.$$ && mv tmp.$$ "$CONFIG_FILE"
 
 # Verify that the JSON file was edited


### PR DESCRIPTION
It looks like some versions of jq don't support the `prop1.["prop2"]` syntax and need instead to be changed to `prop1["prop2"]`.

This bug can be reproduced with jq 1.6 on Ubuntu